### PR TITLE
create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/git-timeclock-backlog-item.md
+++ b/.github/ISSUE_TEMPLATE/git-timeclock-backlog-item.md
@@ -1,0 +1,18 @@
+---
+name: git-timeclock backlog item
+about: A standard git-timeclock backlog item.
+title: ''
+labels: unrefined
+assignees: ''
+
+---
+
+## Justification
+
+**As a** <stakeholder>
+**I want** <thing>
+**So that** <justification>
+
+## Work Required
+
+- Describe the work necessary

--- a/.github/ISSUE_TEMPLATE/git-timeclock-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/git-timeclock-bug-report.md
@@ -1,0 +1,20 @@
+---
+name: git-timeclock bug report
+about: Report an issue with git-timeclock.
+title: "[BUG]"
+labels: bug, unrefined
+assignees: ''
+
+---
+
+## Overview
+
+Provide a concise overview of the issue in one or two sentences.
+
+## Actual
+
+Provide a detailed description of the current actual behavior.
+
+## Expected
+
+Provide a detailed description of the expected behavior.


### PR DESCRIPTION
# create issue templates

## Change Justification

Provide the community consistent templates for backlog items and bugs.

## Description

Create two issue templates:

1. backlog item - used for feature requests, enhancements, tech debt, etc
2. bug - used to report issues with existing functionality 